### PR TITLE
Add consecutive id assignment

### DIFF
--- a/consecutive.py
+++ b/consecutive.py
@@ -221,4 +221,5 @@ def make_consecutive_id():
 
     _make_consecutive_comments_id(core_comment, user_id_to_newid_dict, article_id_to_newid_dict, attach_id_to_newid_dict, comment_id_to_newid_dict)
     print(datetime.now(), 'comment id modification finished')
+
     print(datetime.now(), 'finish db migration :)')

--- a/consecutive.py
+++ b/consecutive.py
@@ -1,3 +1,4 @@
+import random
 from datetime import datetime
 
 from mysql import newara_middle_cursor, newara_middle_db, newara_consecutive_cursor, newara_consecutive_db
@@ -29,6 +30,17 @@ def _make_consecutive_auth_user_id(users):
     newara_consecutive_db.commit()
 
 
+def _make_random_profile_picture() -> str:
+    colors = ['blue', 'red', 'gray']
+    numbers = ['1', '2', '3']
+
+    temp_color = random.choice(colors)
+    temp_num = random.choice(numbers)
+    default_picture = f'user_profiles/default_pictures/{temp_color}-default{temp_num}.png'
+
+    return default_picture
+
+
 def _make_consecutive_user_userprofile_id(users):
     newara_user_userprofile = []
 
@@ -40,7 +52,7 @@ def _make_consecutive_user_userprofile_id(users):
             'uid': user['uid'],
             'sid': user['sid'],
             'sso_user_info': user['sso_user_info'],
-            'picture': user['picture'],
+            'picture': user['picture'] or _make_random_profile_picture(),
             'nickname': user['nickname'],
             'nickname_updated_at': user['nickname_updated_at'],
             'see_sexual': user['see_sexual'],

--- a/consecutive.py
+++ b/consecutive.py
@@ -1,0 +1,224 @@
+from datetime import datetime
+
+from mysql import newara_middle_cursor, newara_middle_db, newara_consecutive_cursor, newara_consecutive_db
+from query import read_queries, write_queries
+
+
+def _make_consecutive_auth_user_id(users):
+    newara_auth_user = []
+
+    for user in users:
+        parsed = {
+            'id': user['new_id'],
+            'password': user['password'],
+            'last_login': user['last_login'],
+            'is_superuser': user['is_superuser'],
+            'username': user['username'],
+            'first_name': user['first_name'],
+            'last_name': user['last_name'],
+            'email': user['email'],
+            'is_staff': user['is_staff'],
+            'is_active': user['is_active'],
+            'date_joined': user['date_joined'],
+        }
+
+        newara_auth_user.append(tuple(parsed.values()))
+
+    print(datetime.now(), 'make consecutive auth_user')
+    newara_consecutive_cursor.executemany(write_queries['auth_user_consecutive'], newara_auth_user)
+    newara_consecutive_db.commit()
+
+
+def _make_consecutive_user_userprofile_id(users):
+    newara_user_userprofile = []
+
+    for user in users:
+        parsed = {
+            'created_at': user['created_at'],
+            'updated_at': user['updated_at'],
+            'deleted_at': user['deleted_at'],
+            'uid': user['uid'],
+            'sid': user['sid'],
+            'sso_user_info': user['sso_user_info'],
+            'picture': user['picture'],
+            'nickname': user['nickname'],
+            'nickname_updated_at': user['nickname_updated_at'],
+            'see_sexual': user['see_sexual'],
+            'see_social': user['see_social'],
+            'extra_preferences': user['extra_preferences'],
+            'user_id': user['new_id'],
+            'is_newara': user['is_newara'],
+            'ara_id': user['ara_id'],
+            'is_kaist': user['is_kaist'],
+        }
+
+        newara_user_userprofile.append(tuple(parsed.values()))
+
+    print(datetime.now(), 'make consecutive user_userprofile')
+    newara_consecutive_cursor.executemany(write_queries['user_userprofile_consecutive'], newara_user_userprofile)
+    newara_consecutive_db.commit()
+
+
+def _make_consecutive_article_id(articles, user_id_to_newid_dict):
+    newara_articles = []
+
+    for article in articles:
+        parsed = {
+            'id': article['new_id'],
+            'created_at': article['created_at'],
+            'updated_at': article['updated_at'],
+            'deleted_at': article['deleted_at'],
+            'title': article['title'],
+            'content': article['content'],
+            'content_text': article['content_text'],
+            'is_anonymous': article['is_anonymous'],
+            'is_content_sexual': article['is_content_sexual'],
+            'is_content_social': article['is_content_social'],
+            'hit_count': article['hit_count'],
+            'positive_vote_count': article['positive_vote_count'],
+            'negative_vote_count': article['negative_vote_count'],
+            'commented_at': article['commented_at'],
+            'created_by_id': user_id_to_newid_dict[article['created_by_id']],
+            'parent_board_id': article['parent_board_id'],
+            'parent_topic_id': article['parent_topic_id'],
+            'url': article['url'],
+        }
+        newara_articles.append(tuple(parsed.values()))
+
+    print(datetime.now(), 'sync articles')
+    newara_consecutive_cursor.executemany(write_queries['core_article_consecutive'], newara_articles)
+    newara_consecutive_db.commit()
+
+
+def _make_consecutive_attachment_id(attachments):
+    newara_attachments = []
+
+    for att in attachments:
+        parsed = {
+            'id': att['new_id'],
+            'created_at': att['created_at'],
+            'updated_at': att['updated_at'],
+            'deleted_at': att['deleted_at'],
+            'file': att['file'],
+            'mimetype': att['mimetype'],
+            'size': att['size'],
+        }
+        newara_attachments.append(tuple(parsed.values()))
+
+    print(datetime.now(), 'make consecutive attachment')
+    newara_consecutive_cursor.executemany(write_queries['core_attachment_consecutive'], newara_attachments)
+    newara_consecutive_db.commit()
+
+
+def _make_consecutive_article_attachments_id(core_article_attachments, article_id_to_newid_dict, attachment_id_to_newid_dict):
+    newara_article_attachments = []
+
+    for a in core_article_attachments:
+        old_article_id = a['article_id']
+        old_attachment_id = a['attachment_id']
+
+        parsed = {
+            'id': a['id'],
+            'article_id': article_id_to_newid_dict[old_article_id],
+            'attachment_id': attachment_id_to_newid_dict[old_attachment_id],
+        }
+
+        newara_article_attachments.append(tuple(parsed.values()))
+
+    print(datetime.now(), 'make consecutive article attachments')
+    newara_consecutive_cursor.executemany(write_queries['core_article_attachments'], newara_article_attachments)
+    newara_consecutive_db.commit()
+
+
+def _make_consecutive_comments_id(comments, user_id_to_newid_dict, article_id_to_newid_dict, attach_id_to_newid_dict, comment_id_to_newid_dict):
+    newara_comments = []
+
+    for c in comments:
+        new_attachment_id = None
+        new_parent_article_id = None
+        new_parent_comment_id = None
+
+        if c['attachment_id']:
+            new_attachment_id = attach_id_to_newid_dict[c['attachment_id']]
+        if c['parent_article_id']:
+            new_parent_article_id = article_id_to_newid_dict[c['parent_article_id']]
+        if c['parent_comment_id']:
+            new_parent_comment_id = comment_id_to_newid_dict[c['parent_comment_id']]
+
+        parsed = {
+            'id': c['new_id'],
+            'created_at': c['created_at'],
+            'updated_at': c['updated_at'],
+            'deleted_at': c['deleted_at'],
+            'content': c['content'],
+            'is_anonymous': c['is_anonymous'],
+            'positive_vote_count': c['positive_vote_count'],
+            'negative_vote_count': c['negative_vote_count'],
+            'attachment_id': new_attachment_id,
+            'created_by_id': user_id_to_newid_dict[c['created_by_id']],
+            'parent_article_id': new_parent_article_id,
+            'parent_comment_id': new_parent_comment_id,
+        }
+
+        newara_comments.append(tuple(parsed.values()))
+
+    print(datetime.now(), 'make consecutive comments')
+    newara_consecutive_cursor.executemany(write_queries['core_comment_consecutive'], newara_comments)
+    newara_consecutive_db.commit()
+
+
+def make_consecutive_id():
+    # make users consecutive
+    FETCH_NUM = 80000
+    newara_middle_cursor.execute(query=read_queries['auth_user'] .format(FETCH_NUM))
+    auth_users = newara_middle_cursor.fetchall()
+
+    user_id_to_newid_dict = {}
+    for au in auth_users:
+        user_id_to_newid_dict[au['id']] = au['new_id']
+
+    _make_consecutive_auth_user_id(auth_users)
+
+    newara_middle_cursor.execute(query=read_queries['user_userprofile'].format(FETCH_NUM))
+    user_userprofiles = newara_middle_cursor.fetchall()
+
+    _make_consecutive_user_userprofile_id(user_userprofiles)
+
+    print(datetime.now(), 'user id modification finished')
+
+    # make articles, attachments, and comments consecutive
+    FETCH_NUM = 600000
+
+    newara_middle_cursor.execute(query=read_queries['core_article'].format(FETCH_NUM))
+    core_articles = newara_middle_cursor.fetchall()
+    _make_consecutive_article_id(core_articles, user_id_to_newid_dict)
+    print(datetime.now(), 'article id modification finished')
+
+    newara_middle_cursor.execute(query=read_queries['core_attachment'].format(FETCH_NUM))
+    core_attachments = newara_middle_cursor.fetchall()
+    _make_consecutive_attachment_id(core_attachments)
+    print(datetime.now(), 'attachment id modification finished')
+
+    newara_middle_cursor.execute(query=read_queries['core_article_attachments'].format(FETCH_NUM))
+    core_article_attachments = newara_middle_cursor.fetchall()
+
+    article_id_to_newid_dict = {}
+    for a in core_articles:
+        article_id_to_newid_dict[a['id']] = a['new_id']
+
+    attach_id_to_newid_dict = {}
+    for att in core_attachments:
+        attach_id_to_newid_dict[att['id']] = att['new_id']
+
+    _make_consecutive_article_attachments_id(core_article_attachments, article_id_to_newid_dict, attach_id_to_newid_dict)
+    print(datetime.now(), 'article attachments id modification finished')
+
+    newara_middle_cursor.execute(query=read_queries['core_comment'].format(FETCH_NUM))
+    core_comment = newara_middle_cursor.fetchall()
+    comment_id_to_newid_dict = {}
+    for c in core_comment:
+        comment_id_to_newid_dict[c['id']] = c['new_id']
+
+    _make_consecutive_comments_id(core_comment, user_id_to_newid_dict, article_id_to_newid_dict, attach_id_to_newid_dict, comment_id_to_newid_dict)
+    print(datetime.now(), 'comment id modification finished')
+    print(datetime.now(), 'finish db migration :)')

--- a/main.py
+++ b/main.py
@@ -3,17 +3,18 @@ from datetime import datetime
 from sync import sync
 from sync_users import sync_users
 from consecutive import make_consecutive_id
+from relink import update_ara_links
 
 import time
-
 
 
 def main():
     print(datetime.now(), 'main start')
     start = time.time()
-    sync_users()
-    sync()
-    make_consecutive_id()
+    # sync_users()
+    # sync()
+    # make_consecutive_id()
+    update_ara_links()
     end = time.time()
     print("Migration took {} seconds".format(end-start))
 

--- a/main.py
+++ b/main.py
@@ -11,9 +11,9 @@ import time
 def main():
     print(datetime.now(), 'main start')
     start = time.time()
-    # sync_users()
-    # sync()
-    # make_consecutive_id()
+    sync_users()
+    sync()
+    make_consecutive_id()
     update_ara_links()
     end = time.time()
     print("Migration took {} seconds".format(end-start))

--- a/main.py
+++ b/main.py
@@ -2,8 +2,10 @@ from datetime import datetime
 
 from sync import sync
 from sync_users import sync_users
+from consecutive import make_consecutive_id
 
 import time
+
 
 
 def main():
@@ -11,6 +13,7 @@ def main():
     start = time.time()
     sync_users()
     sync()
+    make_consecutive_id()
     end = time.time()
     print("Migration took {} seconds".format(end-start))
 

--- a/mysql.py
+++ b/mysql.py
@@ -2,7 +2,7 @@ import pymysql
 
 ara_db = pymysql.connect(
         user='root',
-        passwd='',
+        passwd='jessie',
         host='127.0.0.1',
         db='ara',
         charset='utf8'
@@ -12,7 +12,7 @@ ara_cursor = ara_db.cursor(pymysql.cursors.DictCursor)
 
 newara_middle_db = pymysql.connect(
         user='root',
-        passwd='',
+        passwd='jessie',
         host='127.0.0.1',
         db='new_ara_migration',
         charset='utf8'
@@ -22,7 +22,7 @@ newara_middle_cursor = newara_middle_db.cursor(pymysql.cursors.DictCursor)
 
 newara_consecutive_db = pymysql.connect(
         user='root',
-        passwd='',
+        passwd='jessie',
         host='127.0.0.1',
         db='new_ara_consecutive',
         charset='utf8'

--- a/query.py
+++ b/query.py
@@ -36,6 +36,27 @@ read_queries = {
                             user_id, new_id, is_newara, ara_id, is_kaist
                             from user_userprofile LIMIT {};""",
 
+    'auth_user_consecutive': """select id, password, last_login, is_superuser, username, first_name, last_name,
+                   email, is_staff, is_active, date_joined
+                   from auth_user LIMIT {};""",
+    'user_userprofile_consecutive': """select created_at, updated_at, deleted_at, uid, sid, sso_user_info,
+                           picture, nickname, nickname_updated_at, see_sexual, see_social, extra_preferences,
+                           user_id, is_newara, ara_id, is_kaist
+                           from user_userprofile LIMIT {};""",
+    'core_article_consecutive': """select id, created_at, updated_at, deleted_at, title, content, content_text,
+                    is_anonymous, is_content_sexual, is_content_social, hit_count,
+                    positive_vote_count, negative_vote_count, commented_at, created_by_id, parent_board_id,
+                    parent_topic_id, url
+                     from core_article LIMIT {};""",
+    'core_comment_consecutive': """select id, created_at, updated_at, deleted_at, content,
+                    is_anonymous, positive_vote_count, negative_vote_count, attachment_id, 
+                    created_by_id, parent_article_id, parent_comment_id
+                     from core_comment LIMIT {};""",
+    'core_attachment_consecutive': """select id, created_at, updated_at, deleted_at, file, mimetype, size
+                           from core_attachment LIMIT {};""",
+    'articles_with_ara_links': """select * from core_article where content like '%ara.kaist.ac.kr/%';""",
+    'comments_with_ara_links': """select * from core_comment where content like '%ara.kaist.ac.kr/%';""",
+
 }
 
 # queries without 'consecutive' contain the column 'new_id'
@@ -91,4 +112,10 @@ delete_queries = {
     'core_article_attachments': """delete from core_article_attachments LIMIT {};""",
     'user_userprofile': """delete from user_userprofile LIMIT {};""",
     'auth_user': """delete from auth_user LIMIT {};""",
+}
+
+update_queries = {
+    'core_article_content': """UPDATE core_article SET content = %s, content_text = %s WHERE id = %s;""",
+    'core_comment_content': """UPDATE core_comment SET content = %s WHERE id = %s;""",
+
 }

--- a/query.py
+++ b/query.py
@@ -6,12 +6,12 @@ read_queries = {
                    hit, positive_vote, negative_vote, deleted, destroyed, last_reply_date,
                    root_id, parent_id
                    from articles LIMIT {};""",
-    'core_article': """select id, created_at, updated_at, deleted_at, title, content, content_text,
+    'core_article': """select id, new_id, created_at, updated_at, deleted_at, title, content, content_text,
                        is_anonymous, is_content_sexual, is_content_social, hit_count,
                        positive_vote_count, negative_vote_count, commented_at, created_by_id, parent_board_id,
                        parent_topic_id, url
                         from core_article LIMIT {};""",
-    'core_comment': """select id, created_at, updated_at, deleted_at, content,
+    'core_comment': """select id, new_id, created_at, updated_at, deleted_at, content,
                        is_anonymous, positive_vote_count, negative_vote_count, attachment_id, 
                        created_by_id, parent_article_id, parent_comment_id
                         from core_comment LIMIT {};""",
@@ -24,41 +24,64 @@ read_queries = {
                 authentication_mode, listing_mode, activated_backup, deleted, genuine_email_address
                 from users LIMIT {};""",
 
-    'core_attachment': """select id, created_at, updated_at, deleted_at, file, mimetype, size
+    'core_attachment': """select id, new_id, created_at, updated_at, deleted_at, file, mimetype, size
                             from core_attachment LIMIT {};""",
     'core_article_attachments': """select id, article_id, attachment_id
                             from core_article_attachments LIMIT {};""",
-    'auth_user': """select id, password, last_login, is_superuser, username, first_name, last_name,
+    'auth_user': """select id, new_id, password, last_login, is_superuser, username, first_name, last_name,
                     email, is_staff, is_active, date_joined
                     from auth_user LIMIT {};""",
     'user_userprofile': """select created_at, updated_at, deleted_at, uid, sid, sso_user_info,
-                            picture, nickname, see_sexual, see_social, extra_preferences,
-                            user_id, is_newara, ara_id, is_kaist
+                            picture, nickname, nickname_updated_at, see_sexual, see_social, extra_preferences,
+                            user_id, new_id, is_newara, ara_id, is_kaist
                             from user_userprofile LIMIT {};""",
 
 }
 
+# queries without 'consecutive' contain the column 'new_id'
+# queries with 'consecutive' do not contain the column 'new_id'
 write_queries = {
-    'core_article': """insert into core_article(id, created_at, updated_at, deleted_at, title, content, content_text,
+    'core_article': """insert into core_article(id, new_id, created_at, updated_at, deleted_at, title, content, content_text,
                        is_anonymous, is_content_sexual, is_content_social, hit_count,
                        positive_vote_count, negative_vote_count, commented_at, created_by_id, parent_board_id,
                        parent_topic_id, url)
-                       values (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)""",
-    'core_comment': """insert into core_comment(id, created_at, updated_at, deleted_at, content,
+                       values (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)""",
+    'core_comment': """insert into core_comment(id, new_id, created_at, updated_at, deleted_at, content,
                         is_anonymous, positive_vote_count, negative_vote_count, attachment_id, 
                         created_by_id, parent_article_id, parent_comment_id)
-                        values (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)""",
-    'core_attachment': """insert into core_attachment(id, created_at, updated_at, deleted_at, file, mimetype, size)
-                        values (%s, %s, %s, %s, %s, %s, %s)""",
+                        values (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)""",
+    'core_attachment': """insert into core_attachment(id, new_id, created_at, updated_at, deleted_at, file, mimetype, size)
+                        values (%s, %s, %s, %s, %s, %s, %s, %s)""",
     'core_article_attachments': """insert into core_article_attachments(id, article_id, attachment_id)
                                     values (%s, %s, %s)""",
-    'auth_user': """insert into auth_user(id, password, last_login, is_superuser, username,
+    'auth_user': """insert into auth_user(id, new_id, password, last_login, is_superuser, username,
                     first_name, last_name, email, is_staff, is_active, date_joined)
-                    values (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)""",
+                    values (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)""",
     'user_userprofile': """insert into user_userprofile(created_at, updated_at, deleted_at,
-                            uid, sid, sso_user_info, picture, nickname, see_sexual, see_social,
-                            extra_preferences, user_id, is_newara, ara_id, is_kaist)
-                            values (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)""",
+                            uid, sid, sso_user_info, picture, nickname, nickname_updated_at, see_sexual, see_social,
+                            extra_preferences, user_id, new_id, is_newara, ara_id, is_kaist)
+                            values (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)""",
+
+    'core_article_consecutive': """insert into core_article(id, created_at, updated_at, deleted_at, title, content, content_text,
+                    is_anonymous, is_content_sexual, is_content_social, hit_count,
+                    positive_vote_count, negative_vote_count, commented_at, created_by_id, parent_board_id,
+                    parent_topic_id, url)
+                    values (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)""",
+    'core_comment_consecutive': """insert into core_comment(id, created_at, updated_at, deleted_at, content,
+                     is_anonymous, positive_vote_count, negative_vote_count, attachment_id, 
+                     created_by_id, parent_article_id, parent_comment_id)
+                     values (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)""",
+    'core_attachment_consecutive': """insert into core_attachment(id, created_at, updated_at, deleted_at, file, mimetype, size)
+                     values (%s, %s, %s, %s, %s, %s, %s)""",
+    'core_article_attachments': """insert into core_article_attachments(id, article_id, attachment_id)
+                                 values (%s, %s, %s)""",
+    'auth_user_consecutive': """insert into auth_user(id, password, last_login, is_superuser, username,
+                 first_name, last_name, email, is_staff, is_active, date_joined)
+                 values (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)""",
+    'user_userprofile_consecutive': """insert into user_userprofile(created_at, updated_at, deleted_at,
+                         uid, sid, sso_user_info, picture, nickname, nickname_updated_at, see_sexual, see_social,
+                         extra_preferences, user_id, is_newara, ara_id, is_kaist)
+                         values (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)""",
 }
 
 delete_queries = {

--- a/relink.py
+++ b/relink.py
@@ -1,0 +1,244 @@
+from datetime import datetime
+
+from mysql import ara_cursor, newara_middle_cursor, newara_middle_db, newara_consecutive_cursor, newara_consecutive_db
+from query import read_queries, write_queries, update_queries
+
+
+NEWARA_LINK = 'https://newara.dev.sparcs.org/'
+
+corner_cases = []
+
+article_id_to_newid_dict = {}
+attachment_id_to_newid_dict = {}
+comment_id_to_newid_dict = {}
+comment_get_parent_article_id = {}
+
+old_board_name_to_new_name = {
+    'notice': 'portal',
+    'garbages': 'talk',
+    'food': 'food',
+    'love': 'talk',
+    'wanted': 'wanted',
+    'infoworld': 'talk',
+    'lostfound': 'talk',
+    'hobby': 'talk',
+    'siggame': 'talk',
+    'buysell': 'market',
+    'qanda': 'qa',
+    'funlife': 'talk',
+    'jobs': 'wanted',
+    'housing': 'market',
+}
+
+
+def relink_articles(articles_with_links):
+    newara_articles = []
+
+    for article in articles_with_links:
+        parsed = {
+            'content': replace_link(article['content']),
+            'content_text': replace_link(article['content_text']),
+            'id': article['id'],
+        }
+        newara_articles.append(tuple(parsed.values()))
+
+    # update values
+    print(datetime.now(), 'relink articles')
+    newara_consecutive_cursor.executemany(update_queries['core_article_content'], newara_articles)
+    newara_consecutive_db.commit()
+
+
+def relink_comments(comments_with_links):
+    newara_comments = []
+
+    for c in comments_with_links:
+        parsed = {
+            'content': replace_link(c['content']),
+            'id': c['id'],
+        }
+        newara_comments.append(tuple(parsed.values()))
+
+    print(datetime.now(), 'relink comments')
+    newara_consecutive_cursor.executemany(update_queries['core_comment_content'], newara_comments)
+    newara_consecutive_db.commit()
+
+
+# returns string, with the old link replaced with the new link
+def replace_link(content_str):
+    link_begin_pos = content_str.find('ara.kaist.ac.kr/', 0, -1)
+
+    # termination condition for recursion
+    if link_begin_pos == -1:
+        return content_str
+
+    # identify possible end of link with " " or "\n" or ")"
+    link_end1 = content_str.find('\n', link_begin_pos)
+    link_end2 = content_str.find(' ', link_begin_pos)
+    link_end3 = content_str.find(')', link_begin_pos)
+    link_end4 = content_str.find('"', link_begin_pos)
+    link_end5 = content_str.find('\r', link_begin_pos)
+    link_end6 = content_str.find('을', link_begin_pos)
+    link_end7 = content_str.find('로', link_begin_pos)
+
+    if link_end1 == -1:
+        link_end1 = 1000000
+    if link_end2 == -1:
+        link_end2 = 1000000
+    if link_end3 == -1:
+        link_end3 = 1000000
+    if link_end4 == -1:
+        link_end4 = 1000000
+    if link_end5 == -1:
+        link_end5 = 1000000
+    if link_end6 == -1:
+        link_end6 = 1000000
+    if link_end7 == -1:
+        link_end7 = 1000000
+
+    # identify which candidate is end of link
+    link_end_pos = min((link_end1, link_end2, link_end3, link_end4, link_end5, link_end6, link_end7))
+
+    if link_end_pos == 1000000:
+        link_end_pos = len(content_str)
+
+    old_link = content_str[link_begin_pos:link_end_pos]
+
+    # returns path list
+    path = old_link.lower().split('/')
+
+    # remove 'mobile' from link
+    if (path[1] == 'mobile') or (path[1] == 'm'):
+        del path[1]
+
+    if path[-1] == '':
+        del path[-1]
+
+    # case 1: variation of ara's main page (ex. mobile main page)
+    if len(path) == 1:
+        return content_str
+
+    # case 2: link is board, post, or attachment file
+    elif path[1] == 'board':
+        # case 2-a: link is a board
+        if len(path) < 4:
+            try:
+                new_board_name = old_board_name_to_new_name[path[2]]
+
+            except KeyError: # if this board no longer exists, return original link
+                corner_cases.append(old_link)
+                return content_str
+
+            new_link = NEWARA_LINK + new_board_name
+            return replace_link(content_str.replace(old_link, new_link, 1))
+
+        # case 2-b: link is a file
+        if 'file' in path:
+            file_index = path.index('file')
+            old_attachment_id = int(path[file_index + 1])
+            new_attachment_id = attachment_id_to_newid_dict[old_attachment_id]
+            # TODO: 현재 프론트의 첨부 파일 링크가 구현되지 않아서 attachment/로 넣었습니다. 추후에 구현되면 수정하겠습니다.
+            new_link = NEWARA_LINK + "attachment/" + str(new_attachment_id)
+            return replace_link(content_str.replace(old_link, new_link, 1))
+
+        # case 2-c: write
+        elif path[3] == 'write':
+            new_link = NEWARA_LINK + 'write'
+            return replace_link(content_str.replace(old_link, new_link, 1))
+
+        # case 2-d: link to a post: contains board/{boardName}/{articleID}
+        else:
+            try:
+                old_id = int(path[3].split('#')[0])
+                new_article_id = article_id_to_newid_dict.get(old_id, None)
+                if new_article_id is None:
+                    new_comment_id = comment_id_to_newid_dict[old_id]
+                    new_article_id = comment_get_parent_article_id[new_comment_id]
+
+            except KeyError: # unable to index article/comment
+                corner_cases.append(old_link)
+                return content_str
+
+            except ValueError: # value in link is not a number
+                corner_cases.append(old_link)
+                return content_str
+
+            new_link = NEWARA_LINK + "post/" + str(new_article_id)
+            return replace_link(content_str.replace(old_link, new_link, 1))
+
+    # case 3: 전체게시판/스크랩북의 게시물
+    elif path[1] == 'all' or path[1] == 'scrapbook':
+        if len(path) > 2:
+            try:
+                old_id = int(path[2].split('#')[0])
+                new_article_id = article_id_to_newid_dict.get(old_id, None)
+
+            except KeyError:
+                return content_str
+
+            except ValueError:
+                return content_str
+
+            new_link = NEWARA_LINK + "post/" + str(new_article_id)
+            return replace_link(content_str.replace(old_link, new_link, 1))
+
+        else:
+            new_link = NEWARA_LINK + 'board'
+            return replace_link(content_str.replace(old_link, new_link, 1))
+
+    elif path[1] == 'main':
+        return replace_link(content_str.replace(old_link, NEWARA_LINK, 1))
+
+    # TODO: 현재 black list page가 없어서 이 부분을 구현하지 못했습니다. 추후에 blacklist가 생기면 구현하겠습니다.
+    # case 4: link to blacklist page
+    elif old_link.find('blacklist') > -1:
+        return content_str
+
+    else: # if not in these cases, accumulate link in a list and print later, to find corner cases
+        corner_cases.append(old_link)
+        return content_str
+
+
+def update_ara_links():
+    # check articles
+    FETCH_NUM = 600000
+    newara_middle_cursor.execute(query=read_queries['core_article'].format(FETCH_NUM))
+    core_articles = newara_middle_cursor.fetchall()
+
+    # create dictionary mapping old article id -> new article id
+    for a in core_articles:
+        article_id_to_newid_dict[a['id']] = a['new_id']
+
+    newara_middle_cursor.execute(query=read_queries['core_comment'].format(FETCH_NUM))
+    core_comment = newara_middle_cursor.fetchall()
+
+    # create dictionary mapping old comment id -> new comment id
+    for c in core_comment:
+        comment_id_to_newid_dict[c['id']] = c['new_id']
+        comment_get_parent_article_id[c['id']] = c['parent_article_id']
+
+    newara_middle_cursor.execute(query=read_queries['core_attachment'].format(FETCH_NUM))
+    core_attachment = newara_middle_cursor.fetchall()
+
+    # create dictionary mapping old attachment id -> new attachment id
+    for att in core_attachment:
+        attachment_id_to_newid_dict[att['id']] = att['new_id']
+
+    # identify all articles that contain "ara.kaist.ac.kr"
+    newara_consecutive_cursor.execute(query=read_queries['articles_with_ara_links'].format(FETCH_NUM))
+    articles_with_links = newara_consecutive_cursor.fetchall()
+
+    relink_articles(articles_with_links)
+
+    # check comments
+
+    print('start relinking comments')
+
+    # identify all comments that contain "ara.kaist.ac.kr"
+    newara_consecutive_cursor.execute(query=read_queries['comments_with_ara_links'].format(FETCH_NUM))
+    comments_with_links = newara_consecutive_cursor.fetchall()
+
+    relink_comments(comments_with_links)
+
+    print("corner cases: ")
+    for c in corner_cases:
+        print(c)

--- a/relink.py
+++ b/relink.py
@@ -14,7 +14,7 @@ comment_id_to_newid_dict = {}
 comment_get_parent_article_id = {}
 
 old_board_name_to_new_name = {
-    'notice': 'portal',
+    'notice': 'portal-notice',
     'garbages': 'talk',
     'food': 'food',
     'love': 'talk',
@@ -179,7 +179,7 @@ def replace_link(content_str):
             return replace_link(content_str.replace(old_link, new_link, 1))
 
     # case 3: link is query on all boards
-    elif path[2] == 'search':
+    elif len(path) > 2 and path[2] == 'search':
         search_word_pos = path[3].find('search_word=') + 12
         search_word = path[3][search_word_pos:]
 
@@ -187,7 +187,7 @@ def replace_link(content_str):
 
         return replace_link(content_str.replace(old_link, new_link, 1))
 
-    # case 3: 전체게시판/스크랩북의 게시물
+    # case 4: 전체게시판/스크랩북의 게시물
     elif path[1] == 'all' or path[1] == 'scrapbook':
         if len(path) > 2:
             try:
@@ -208,10 +208,11 @@ def replace_link(content_str):
 
         return replace_link(content_str.replace(old_link, new_link, 1))
 
+    # case 5: 메인페이지
     elif path[1] == 'main':
         return replace_link(content_str.replace(old_link, NEWARA_LINK, 1))
 
-    # case 4: link to blacklist page
+    # case 6: link to blacklist page
     elif old_link.find('blacklist') > -1:
         new_link = NEWARA_LINK + 'myinfo' # 뉴아라에서는 blacklist를 마이페이지에서 볼 수 있음
         return replace_link(content_str.replace(old_link, new_link, 1))

--- a/sync.py
+++ b/sync.py
@@ -94,6 +94,10 @@ def _match_board_and_topic(ara_board, ara_heading):
         return (None, None)
 
 
+def _replace_enter(s):
+    return s.replace('\r\n', '<br>').replace('\n', '<br>')
+
+
 def _sync_articles(articles, auth_users_dict):
     newara_articles = []
 
@@ -116,7 +120,7 @@ def _sync_articles(articles, auth_users_dict):
                 'updated_at': (article['date'] - timedelta(hours=9)).isoformat(),
                 'deleted_at': ((article['date'] - timedelta(hours=9)) if article['deleted'] else datetime.min).isoformat(),
                 'title': article['title'],
-                'content': article['content'],
+                'content': _replace_enter(article['content']),
                 'content_text': ' '.join(bs4.BeautifulSoup(article['content'], features='html5lib').find_all(text=True)),
                 'is_anonymous': False,
                 'is_content_sexual': False,

--- a/sync.py
+++ b/sync.py
@@ -370,7 +370,7 @@ def sync():
 
     print("fetched files and articles")
 
-    # _sync_articles(articles, auth_users_dict)
+    _sync_articles(articles, auth_users_dict)
     _sync_attachments(files, articles_dict)
 
     newara_middle_cursor.execute(query=read_queries['core_article'].format(FETCH_NUM))

--- a/sync.py
+++ b/sync.py
@@ -34,7 +34,7 @@ def _match_board_and_topic(ara_board, ara_heading):
         10: (2, 9),
         9: (2, 4),
         8: (2, 1),
-        4: (4, 13),
+        4: (7, 13),
         1: (7, None),
         2: (7, None),
         3: (7, None),

--- a/sync_users.py
+++ b/sync_users.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 
 # import boto3 as boto3
 # import bs4 as bs4
@@ -7,7 +7,7 @@ from datetime import datetime
 from mysql import ara_cursor, newara_middle_cursor, newara_middle_db
 from query import read_queries, write_queries
 
-
+#
 # s3 = boto3.resource('s3')
 # client = boto3.client('s3')
 
@@ -21,13 +21,13 @@ def _sync_auth_user(users, miss_users):
             if user['username'] == "??": username = "dup??"
             else: username = user['username']
 
-            if not user['join_time']: join_time = datetime.now().isoformat()
-            else: join_time = user['join_time'].isoformat()
+            if not user['join_time']: join_time = (datetime.now() - timedelta(hours=9)).isoformat()
+            else: join_time = (user['join_time'] - timedelta(hours=9)).isoformat()
             parsed = {
                 'id': user['id'],
                 'new_id': new_id_val,
                 'password': user['password'],
-                'last_login': (user['last_login_time'] if user['last_login_time'] else datetime.min).isoformat(),
+                'last_login': ((user['last_login_time'] - timedelta(hours=9)) if user['last_login_time'] else datetime.min).isoformat(),
                 'is_superuser': 0,
                 'username': username or "__deleted__{}".format(user['id']),
                 'first_name': "",
@@ -88,11 +88,11 @@ def _sync_user_userprofile(users, auth_users_dict, id_to_newid_dict, users_name_
                 nickname = user['username']
 
             if not user['join_time']: join_time = datetime.now().isoformat()
-            else: join_time = user['join_time'].isoformat()
+            else: join_time = (user['join_time'] - timedelta(hours=9)).isoformat()
             parsed = {
                 'created_at': join_time,
                 'updated_at': join_time,
-                'deleted_at': (user['last_login_time'] if user['deleted'] else datetime.min).isoformat(),
+                'deleted_at': ((user['last_login_time'] - timedelta(hours=9)) if user['deleted'] else datetime.min).isoformat(),
                 'uid': None,
                 'sid': None,
                 'sso_user_info': "{}",
@@ -143,13 +143,14 @@ def get_use_id(auth_users, user_id):
         if auth_user['id'] == user_id:
             return auth_user['id']
 
+
 def sync_users():
     FETCH_NUM = 80000
 
     ara_cursor.execute(query=read_queries['users'] .format(FETCH_NUM))
     users = ara_cursor.fetchall()
 
-    miss_users = [65673, 69660]
+    miss_users = [65673, 69660, 81408]
 
     users_name_dict = {}
     # for u in users:


### PR DESCRIPTION
1. auth_user, user_userprofile, core_article, core_attachment, core_comment에 new_id라는 column을 만들었습니다.
기존의 Migration이 되는 과정에서, new_ara_migration DB의 이 table들의 new_id에 연속적인 id를 넣어줍니다.

2. 그 다음에, new_ara_consecutive DB에 한번 더 migrate 해줍니다. 이 때는 새로 들어가는 auth_user, user_userprofile, core_article, core_attachment, core_article_attachments, core_comment들의 id를 new_id 값으로 대체해줍니다. 

제 컴퓨터에서는 1번이 돌아가는데 70분, 2번이 돌아가는데 10분 이내로 걸렸습니다.

1번에서 new_id를 위해서, 기존 query.py에서 1번의 항목들에 대해서 new_id를 포함시켰습니다.
2번을 위해서, query.py에 new_id가 들어가지않은 쿼리들은 이름 뒤에 '_consecutive'를 붙여서 사용하였습니다.